### PR TITLE
HashTables take void pointer as parameters

### DIFF
--- a/modules/tools/hashmap.c
+++ b/modules/tools/hashmap.c
@@ -7,15 +7,14 @@
 static Hash_Node HASH_DELETED_NODE = {NULL, NULL};
 
 
-static Hash_Node* hash_new_node(const char* k, const char* v) {
+static Hash_Node* hash_new_node(const char* k, const void* v) {
 	Hash_Node* node = malloc(sizeof(Hash_Node));
 	node->key = strdup(k);
 	node->value = strdup(v);
 	return node;
 }
 
-// hash_insert(hash, "--argument", "rojo");
-void hash_insert(Hash_Table* hash, const char* key, const char* value) {
+void hash_insert(Hash_Table* hash, const char* key, const void* value) {
 	Hash_Node* item = hash_new_node(key, value);
 	int index = hash_code(item->key, hash->size, 0);
 	Hash_Node* cur_item = hash->items[index];
@@ -34,8 +33,8 @@ void hash_insert(Hash_Table* hash, const char* key, const char* value) {
 	hash->count++;
 }
 
-// hash_search(hash, "--argument");
-char* hash_search(Hash_Table* hash, const char* key) {
+
+void* hash_search(Hash_Table* hash, const char* key) {
 	int index = hash_code(key, hash->size, 0);
 	Hash_Node *item = hash->items[index];
 	int i = 1;

--- a/modules/tools/hashmap.h
+++ b/modules/tools/hashmap.h
@@ -13,7 +13,7 @@
 // hash_table.h
 typedef struct {
 	char* key;
-	char* value;
+	void* value;
 }Hash_Node; // ht_item
 
 typedef struct {
@@ -23,9 +23,9 @@ typedef struct {
 } Hash_Table; // ht_hash_table
 
 Hash_Table* new_hash(); // ht_new
-void hash_insert(Hash_Table* hash, const char* key, const char* value); // ht_insert 
-char* hash_search(Hash_Table* hash, const char* key); // ht_search
-static Hash_Node* hash_new_item(const char* k, const char* v); // ht_new_item
+void hash_insert(Hash_Table* hash, const char* key, const void* value); // ht_insert 
+void* hash_search(Hash_Table* hash, const char* key); // ht_search
+static Hash_Node* hash_new_item(const char* k, const void* v); // ht_new_item
 static void hash_delete_node(Hash_Node *i); // ht_del_item
 void hash_delete(Hash_Table* hash, const char* key); //ht_delete
 static int hash(const char* s, const int a, const int m); // ht_hash


### PR DESCRIPTION
# Description

Initially, I thought char* would be good for an argument tool, however, I realized I may need to store even more information (like emails and so forth) as the program grows. For that reason, it is better to store it in a struct and store that struct inside the hashtable. That way the Arg struct can be referenced called the argument on itself directly. Now hashtables take a void pointer as a parameter I can convert to an Arg pointer with a simple function call.

## Type of change
      structural

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
    info is in the testing file

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules